### PR TITLE
[BETT-1717] locaiton 타입 변경

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knowmerce/delivery-tracker-core",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "commonjs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/src/carriers/common/convert.interface.ts
+++ b/packages/core/src/carriers/common/convert.interface.ts
@@ -1,5 +1,9 @@
 import { TrackEventStatusCode, type TrackInfo } from "../../core";
 
+interface ConvertTrackInfoResponseProgressLocation {
+  name?: string | null;
+}
+
 interface ConvertTrackInfoResponseStatus {
   id: TrackEventStatusCode; // 이 프로젝트에 정의된 상태값 사용
   text: string | null;
@@ -17,7 +21,7 @@ interface ConvertTrackInfoResponseTo {
 
 interface ConvertTrackInfoResponseProgress {
   time: string | null;
-  location?: string | null;
+  location?: ConvertTrackInfoResponseProgressLocation;
   status: ConvertTrackInfoResponseStatus;
   description: string | null;
 }
@@ -42,7 +46,7 @@ export const convertTrackInfo = (
         each.time !== null
           ? `${each.time.toFormat("yyyy-MM-dd HH:mm:ss")}+09:00`
           : null,
-      location: each.location?.name,
+      location: { name: each.location?.name },
       status: { id: each.status.code, text: each.status.name },
       description: each.description,
     })),


### PR DESCRIPTION
## 기획서, 피그마, 지라 링크
https://wonderwallmessage.atlassian.net/browse/BETT-1717
## 주요 변경 사항
ConvertTrackInfoResponseProgress의 location 타입을 변경했습니다.
기존 v1의 타입에서 null 타입만 추가되었고 프론트 코드 수정을 안하기 위해서 v1과 맞췄습니다.
## 고민했던 부분

## 주의깊게 봐줬으면 하는 부분

## 최종 배포 일정
now